### PR TITLE
chore: add deth support for basescan

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ Whenever you change dependencies (adding, removing, or updating, either in `pack
 - moonscan.io
 - snowtrace.io
 - optimistic.etherscan.io
+- basescan.org
 - opensea.io
 
 ## Changelog

--- a/manifest.config.ts
+++ b/manifest.config.ts
@@ -25,7 +25,8 @@ export default defineManifest((env: ConfigEnv) => ({
         '*://arbiscan.io/*',
         '*://ftmscan.com/*',
         '*://cronoscan.com/*',
-        '*://*.moonscan.io/*'
+        '*://*.moonscan.io/*',
+        '*://*.basescan.org/*'
       ],
       js: ['src/content/scans/index.tsx'],
       all_frames: true
@@ -84,6 +85,7 @@ export default defineManifest((env: ConfigEnv) => ({
     '*://ftmscan.com/*',
     '*://cronoscan.com/*',
     '*://*.moonscan.io/*',
+    '*://*.basescan.org/*',
     '*://*.blocksec.com/*',
     '*://explorer.api.btc.com/*'
   ]

--- a/src/common/constants/support.ts
+++ b/src/common/constants/support.ts
@@ -93,6 +93,14 @@ export const EXT_SUPPORT_WEB_LIST: ExtSupportWebsite[] = [
     logo: 'https://assets.blocksec.com/image/1671777583236-2.png'
   },
   {
+    name: 'Base',
+    chainID: 8453,
+    chain: 'base',
+    domains: ['basescan.org'],
+    siteName: 'SCAN',
+    logo: 'https://assets.blocksec.com/image/1671777583236-2.png'
+  },
+  {
     name: 'OpenSea',
     domains: ['opensea.io'],
     siteName: 'OPENSEA'
@@ -213,6 +221,10 @@ export const TENDERLY_SUPPORT_LIST = [
   {
     pathname: 'optimistic',
     chain: 'optimism'
+  },
+  {
+    pathname: 'base',
+    chain: 'base'
   }
 ]
 
@@ -260,6 +272,10 @@ export const ETHERSCAN_DETH_SUPPORT_LIST = [
   {
     chain: 'cronos',
     url: 'https://cronoscan.deth.net/address'
+  },
+  {
+    chain: 'base',
+    url: 'https://basescan.deth.net/address'
   }
 ]
 


### PR DESCRIPTION
## What Changed?

- Add DethCode support for Basescan
  - [DethCode added support for Basescan.org in this PR](https://github.com/dethcrypto/dethcode/pull/82)
- Add Base to Tenderly support list
  - Tenderly [has Base support](https://blog.tenderly.co/how-to-build-on-base-network-with-tenderly/) from Day 1
- Update `manifest.config.js` with `basescan.org` URLs (`www.` redirects to `basescan.org` btw)
- Update README.md

## Additional Info

- I couldn't find the URL for the Base icon on `https://assets.blocksec.com/image/*.png`
  - Please update this PR with a valid icon (currently using Optimistic's logo as a placeholder)